### PR TITLE
Ft/ Add getDeviceData method to iOS

### DIFF
--- a/ios/RNBraintreeDropIn.h
+++ b/ios/RNBraintreeDropIn.h
@@ -7,10 +7,13 @@
 #import "BraintreeCore.h"
 #import "BraintreeDropIn.h"
 #import "BTCardNonce.h"
+#import "BTDataCollector.h"
 
 @interface RNBraintreeDropIn : NSObject <RCTBridgeModule>
 
 @property (nonatomic, strong) UIViewController* _Nonnull reactRoot;
+
+@property (nonatomic, strong) BTDataCollector *dataCollector;
 
 + (void)resolvePayment:(BTDropInResult* _Nullable)result resolver:(RCTPromiseResolveBlock _Nonnull)resolve;
 

--- a/ios/RNBraintreeDropIn.m
+++ b/ios/RNBraintreeDropIn.m
@@ -8,6 +8,24 @@
 }
 RCT_EXPORT_MODULE()
 
+RCT_EXPORT_METHOD(getDeviceData:(NSDictionary*)options
+                       resolver: (RCTPromiseResolveBlock)resolve
+                       rejecter: (RCTPromiseRejectBlock)reject)
+{
+    NSString* clientToken = options[@"clientToken"];
+    if (!clientToken) {
+        reject(@"NO_CLIENT_TOKEN", @"You must provide a client token", nil);
+        return;
+    }
+
+    BTAPIClient *apiClient = [[BTAPIClient alloc] initWithAuthorization:clientToken];
+    self.dataCollector = [[BTDataCollector alloc] initWithAPIClient:apiClient];
+
+    [self.dataCollector collectCardFraudData:^(NSString * _Nonnull deviceData) {
+        resolve(deviceData);
+    }];
+}
+
 RCT_REMAP_METHOD(show,
                  showWithOptions:(NSDictionary*)options resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {


### PR DESCRIPTION
Add `getDeviceData` method to collect deviceData on iOS

When `Review` component is mounted, if is paying via credit card and platform is iOS, we call `getDeviceData` to get device data and store it to redux store.