### PR TITLE
Fix: Cardinal Credential is oudated

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,10 +41,10 @@ dependencies {
 rootProject.allprojects {
     repositories {
         maven {
-            url  "https://cardinalcommerce.bintray.com/android"
+            url  "https://cardinalcommerceprod.jfrog.io/artifactory/android"
             credentials {
-                username 'braintree-team-sdk@cardinalcommerce'
-                password '220cc9476025679c4e5c843666c27d97cfb0f951'
+                username 'braintree_team_sdk'
+                password 'AKCp8jQcoDy2hxSWhDAUQKXLDPDx6NYRkqrgFLRc3qDrayg6rrCbJpsKKyMwaykVL8FWusJpp'
             }
         }
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,6 @@ buildscript {
     repositories {
         jcenter()
         google()
-        // https://developers.braintreepayments.com/guides/3d-secure/migration/android/v3
-        maven {
-            url  "https://cardinalcommerceprod.jfrog.io/artifactory/android"
-            credentials {
-                username 'braintree_team_sdk'
-                password 'AKCp8jQcoDy2hxSWhDAUQKXLDPDx6NYRkqrgFLRc3qDrayg6rrCbJpsKKyMwaykVL8FWusJpp'
-            }
-        }
     }
 
     dependencies {
@@ -43,4 +35,17 @@ dependencies {
     implementation 'com.braintreepayments.api:drop-in:4.5.0'
     implementation 'com.facebook.react:react-native:+'
     implementation 'com.braintreepayments.api:data-collector:3.+'
+}
+
+// https://developers.braintreepayments.com/guides/3d-secure/migration/android/v3
+rootProject.allprojects {
+    repositories {
+        maven {
+            url  "https://cardinalcommerceprod.jfrog.io/artifactory/android"
+            credentials {
+                username 'braintree_team_sdk'
+                password 'AKCp8jQcoDy2hxSWhDAUQKXLDPDx6NYRkqrgFLRc3qDrayg6rrCbJpsKKyMwaykVL8FWusJpp'
+            }
+        }
+    }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,6 +2,14 @@ buildscript {
     repositories {
         jcenter()
         google()
+        // https://developers.braintreepayments.com/guides/3d-secure/migration/android/v3
+        maven {
+            url  "https://cardinalcommerceprod.jfrog.io/artifactory/android"
+            credentials {
+                username 'braintree_team_sdk'
+                password 'AKCp8jQcoDy2hxSWhDAUQKXLDPDx6NYRkqrgFLRc3qDrayg6rrCbJpsKKyMwaykVL8FWusJpp'
+            }
+        }
     }
 
     dependencies {
@@ -35,17 +43,4 @@ dependencies {
     implementation 'com.braintreepayments.api:drop-in:4.5.0'
     implementation 'com.facebook.react:react-native:+'
     implementation 'com.braintreepayments.api:data-collector:3.+'
-}
-
-// https://developers.braintreepayments.com/guides/3d-secure/migration/android/v3
-rootProject.allprojects {
-    repositories {
-        maven {
-            url  "https://cardinalcommerceprod.jfrog.io/artifactory/android"
-            credentials {
-                username 'braintree_team_sdk'
-                password 'AKCp8jQcoDy2hxSWhDAUQKXLDPDx6NYRkqrgFLRc3qDrayg6rrCbJpsKKyMwaykVL8FWusJpp'
-            }
-        }
-    }
 }


### PR DESCRIPTION
# Summary
```Could not determine the dependencies of task ':app:lintVitalStagingRelease'.
> Could not resolve all artifacts for configuration ':app:stagingDebugRuntimeClasspath'.
   > Could not resolve org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:2.2.1-2.
     Required by:
         project :app > project :react-native-braintree-payments-drop-in > com.braintreepayments.api:drop-in:4.5.0 > com.braintreepayments.api:three-d-secure:3.7.2
      > Could not resolve org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:2.2.1-2.
         > Could not get resource 'https://dl.bintray.com/android/android-tools/org/jfrog/cardinalcommerce/gradle/cardinalmobilesdk/2.2.1-2/cardinalmobilesdk-2.2.1-2.pom'.
            > Could not GET 'https://dl.bintray.com/android/android-tools/org/jfrog/cardinalcommerce/gradle/cardinalmobilesdk/2.2.1-2/cardinalmobilesdk-2.2.1-2.pom'. Received status code 403 from server: Forbidden
      > Could not resolve org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:2.2.1-2.
         > Could not get resource 'https://cardinalcommerce.bintray.com/android/org/jfrog/cardinalcommerce/gradle/cardinalmobilesdk/2.2.1-2/cardinalmobilesdk-2.2.1-2.pom'.
            > Could not GET 'https://cardinalcommerce.bintray.com/android/org/jfrog/cardinalcommerce/gradle/cardinalmobilesdk/2.2.1-2/cardinalmobilesdk-2.2.1-2.pom'. Received status code 403 from server: Forbidden
```
Our CI builds are broken because of this issue, I found that the Cardinal Credential is outdated. Following to [this PR](https://github.com/braintree/braintree-android-drop-in/pull/244), I have changed the credential of Cardinal

# Tesing
CI build is green after my fix https://app.circleci.com/pipelines/github/Thinkei/eh-mobile-pro/9197/workflows/7b223289-af34-45b9-b9b6-f7807e4e8f4d