### PR TITLE
fix: [android] align logic handler with ios

### DIFF
--- a/android/src/main/java/tech/bam/RNBraintreeDropIn/RNBraintreeDropInModule.java
+++ b/android/src/main/java/tech/bam/RNBraintreeDropIn/RNBraintreeDropInModule.java
@@ -94,11 +94,14 @@ public class RNBraintreeDropInModule extends ReactContextBaseJavaModule {
         if (isVerifyingThreeDSecure && paymentMethodNonce instanceof CardNonce) {
           CardNonce cardNonce = (CardNonce) paymentMethodNonce;
           ThreeDSecureInfo threeDSecureInfo = cardNonce.getThreeDSecureInfo();
-          if (!threeDSecureInfo.isLiabilityShiftPossible()) {
-            mPromise.reject("3DSECURE_NOT_ABLE_TO_SHIFT_LIABILITY", "3D Secure liability was not shifted");
-          } else if (!threeDSecureInfo.isLiabilityShifted()) {
-            mPromise.reject("3DSECURE_LIABILITY_NOT_SHIFTED", "3D Secure liability was not shifted");
+          if (threeDSecureInfo.isLiabilityShiftPossible()) { // Card is eligible for 3D secure
+            if (threeDSecureInfo.isLiabilityShifted()) { // 3D Secure authentication success
+               resolvePayment(paymentMethodNonce, deviceData);
+            } else {
+               mPromise.reject("3DSECURE_LIABILITY_NOT_SHIFTED", "3D Secure liability was not shifted");
+            }
           } else {
+            // 3D Secure is not support, we allow users to continue without 3D Secure
             resolvePayment(paymentMethodNonce, deviceData);
           }
         } else {


### PR DESCRIPTION
- Braintree recently upgrade our instances silently to 2.1.0 make the 3ds breaks
- After the break, ios by pass 3ds secure, but android failed because this wrapper have different logic handler
- This fix sastified the POs team when they want user able to use payment even without 3ds secure

demo android :

https://user-images.githubusercontent.com/107666563/198708398-29f686e0-415e-49ab-8dd2-2e256c073942.MOV


