### PR TITLE
[No Jira] Fix: Updagre braintree drop in android lib

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,7 +32,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.braintreepayments.api:drop-in:4.5.0'
+    implementation 'com.braintreepayments.api:drop-in:5.4.0'
     implementation 'com.facebook.react:react-native:+'
     implementation 'com.braintreepayments.api:data-collector:3.+'
 }


### PR DESCRIPTION
# Summary
Android app version 1.74.0 got rejected because of missing Google Policy compliance
https://github.com/braintree/braintree-android-drop-in/issues/373
After [a discussion](https://employmenthero.slack.com/archives/C04PC10SU5S/p1676274155561759) with eBen team, we decided to upgrade braintree drop in for Android to version 5.4.0